### PR TITLE
Implement MMP_compressed_texture

### DIFF
--- a/src/elements/Image.ts
+++ b/src/elements/Image.ts
@@ -8,71 +8,141 @@ import GltfTypes from '../types/GltfTypes';
 import { IElement } from '../types/Elements';
 import { AbortSignalLike } from '@azure/abort-controller';
 import { createNativeSignal } from '../lib/cancellation';
+import Texture2D from 'nanogl/texture-2d';
+import { GLContext } from 'nanogl/types';
 
 
-const _HAS_CIB : boolean = ( window.createImageBitmap !== undefined );
+const _HAS_CIB: boolean = (window.createImageBitmap !== undefined);
+
+const GL_REPEAT                         = 0x2901;
+const GL_MIRRORED_REPEAT                = 0x8370;
+
+export function filterHasMipmap(filter : GLenum) : boolean {
+  return (filter & (1 << 8)) === (1 << 8);
+}
+
+export function wrapRequirePot(wrap : GLenum ) : boolean {
+  return wrap === GL_REPEAT || wrap === GL_MIRRORED_REPEAT;
+}
+
+export function isPowerOf2(n : number ) : boolean {
+  return (n != 0 && (n & (n-1)) === 0);
+}
+
+function nearestPowerOf2(n:number) : number {
+    if( isPowerOf2(n) ) return n;
+    if (n % 2 === 1) n++;
+    return Math.pow(2.0, Math.round(Math.log(n) / Math.log(2.0)));
+}
+
+
+
 
 export default class Image implements IElement {
 
-  readonly gltftype : GltfTypes.IMAGE = GltfTypes.IMAGE;
+  readonly gltftype: GltfTypes.IMAGE = GltfTypes.IMAGE;
 
-  name        : undefined | string;
-  extras      : any   ;
+  name: undefined | string;
+  extras: any;
 
-  uri?         : string;
-  resolvedUri? : string;
-  mimeType?    : Gltf2.ImageMimeType;
-  bufferView?  : BufferView;
-  
-  texImageSource : TexImageSource;
+  uri?: string;
+  resolvedUri?: string;
+  mimeType?: Gltf2.ImageMimeType;
+  bufferView?: BufferView;
 
-  async parse( gltfLoader:GltfLoader, data: Gltf2.IImage ) : Promise<any>{
+  texImageSource: TexImageSource;
 
-    if( data.uri ){
+  async parse(gltfLoader: GltfLoader, data: Gltf2.IImage): Promise<any> {
+
+    if (data.uri) {
       this.uri = data.uri;
 
-      if( this.uri.indexOf('data:' )==0 ){
+      if (this.uri.indexOf('data:') == 0) {
         this.resolvedUri = this.uri;
       } else {
-        this.resolvedUri = gltfLoader.resolveUri( this.uri );
+        this.resolvedUri = gltfLoader.resolveUri(this.uri);
       }
     }
 
-    
-    
-    this.mimeType = data.mimeType;
-    
-    if( data.bufferView !== undefined ){
-      this.bufferView = await gltfLoader.getElement( GltfTypes.BUFFERVIEW, data.bufferView );
-    }
-    
 
-    
+
+    this.mimeType = data.mimeType;
+
+    if (data.bufferView !== undefined) {
+      this.bufferView = await gltfLoader.getElement(GltfTypes.BUFFERVIEW, data.bufferView);
+    }
+
+
+
     const blob = await this.loadImageBlob(gltfLoader.abortSignal);
-    this.texImageSource = await gltfLoader.gltfIO.loadImageBlob( blob, gltfLoader.abortSignal );
+    this.texImageSource = await gltfLoader.gltfIO.loadImageBlob(blob, gltfLoader.abortSignal);
 
   }
 
-  private async loadImageBlob( abortSignal : AbortSignalLike ) : Promise<Blob> {
+  protected async loadImageBlob(abortSignal: AbortSignalLike): Promise<Blob> {
 
-    if( this.bufferView ){
+    if (this.bufferView) {
       // mimeType is guaranted here
-      const arrayView = new Uint8Array( 
-        this.bufferView.buffer._bytes, 
-        this.bufferView.getByteOffset(), 
-        this.bufferView.byteLength 
-        );
-        return new Blob( [arrayView] , { type: this.mimeType });
-      } else {
-        // assume uri is defained as uri or data uri
-      const signal = createNativeSignal( abortSignal )
-      const request = await fetch( this.resolvedUri, {signal} )
+      const arrayView = new Uint8Array(
+        this.bufferView.buffer._bytes,
+        this.bufferView.getByteOffset(),
+        this.bufferView.byteLength
+      );
+      return new Blob([arrayView], { type: this.mimeType });
+    } else {
+      // assume uri is defained as uri or data uri
+      const signal = createNativeSignal(abortSignal)
+      const request = await fetch(this.resolvedUri, { signal })
       const blob = await request.blob();
       return blob;
     }
+
   }
 
- 
+  public async setupTexture(texture: Texture2D, wrapS : GLenum, wrapT : GLenum, minFilter : GLenum, magFilter: GLenum) {
+
+    const gl = texture.gl;
+
+   let texImageSource = this.texImageSource;
+   if( wrapRequirePot(wrapS) || wrapRequirePot( wrapT ) || filterHasMipmap(minFilter) ){
+     if( !isPowerOf2(texImageSource.width) || !isPowerOf2(texImageSource.height) )
+     texImageSource = await this.resizeToPOT( texImageSource, gl );
+    }
+
+    texture.fromImage(this.texImageSource);
+
+    if( filterHasMipmap(minFilter) ){
+      gl.generateMipmap( gl.TEXTURE_2D );
+    }
+
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, magFilter);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, minFilter);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrapS);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrapT);
+
+    return null;
+
+  }
+
+  async resizeToPOT( source: TexImageSource, gl : GLContext ) : Promise<TexImageSource> {
+
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+    canvas.width  = nearestPowerOf2( source.width );
+    canvas.height = nearestPowerOf2( source.height );
+    
+    if( source instanceof ImageData ){
+      const imageBitmap = await  createImageBitmap( source, 0, 0, canvas.width, canvas.height );
+      context.drawImage(imageBitmap, 0, 0, canvas.width, canvas.height);
+    } else {
+      context.drawImage(source, 0, 0, canvas.width, canvas.height);
+    }
+
+    return canvas;
+
+  }
+
+
 
 }
 

--- a/src/elements/Texture.ts
+++ b/src/elements/Texture.ts
@@ -12,29 +12,6 @@ import { IElement } from '../types/Elements';
 import Deferred from '../lib/Deferred';
 
 
-const GL_REPEAT                         = 0x2901;
-const GL_MIRRORED_REPEAT                = 0x8370;
-
-export function filterHasMipmap(filter : GLenum) : boolean {
-  return (filter & (1 << 8)) === (1 << 8);
-}
-
-export function wrapRequirePot(wrap : GLenum ) : boolean {
-  return wrap === GL_REPEAT || wrap === GL_MIRRORED_REPEAT;
-}
-
-export function isPowerOf2(n : number ) : boolean {
-  return (n != 0 && (n & (n-1)) === 0);
-}
-
-function nearestPowerOf2(n:number) : number {
-    if( isPowerOf2(n) ) return n;
-    if (n % 2 === 1) n++;
-    return Math.pow(2.0, Math.round(Math.log(n) / Math.log(2.0)));
-}
-
-
-
 export default class Texture implements IElement {
 
   readonly gltftype : GltfTypes.TEXTURE = GltfTypes.TEXTURE;
@@ -75,6 +52,7 @@ export default class Texture implements IElement {
       glFormat = gl.RGBA;
 
 
+
     let minFilter : GLenum = gl.LINEAR
     let magFilter : GLenum = gl.LINEAR
 
@@ -87,55 +65,20 @@ export default class Texture implements IElement {
       wrapS = this.sampler.wrapS
       wrapT = this.sampler.wrapT
     }
-
     
-    /*
-      TODO: implement texture resize
-      Resize source to POT if needed : if the sampler the texture references
-      Has a wrapping mode (either wrapS or wrapT) equal to REPEAT or MIRRORED_REPEAT, or
-      Has a minification filter (minFilter) that uses mipmapping (NEAREST_MIPMAP_NEAREST, NEAREST_MIPMAP_LINEAR, LINEAR_MIPMAP_NEAREST, or LINEAR_MIPMAP_LINEAR).
-    */
-    let texImageSource = this.source.texImageSource;
-    if( wrapRequirePot(wrapS) || wrapRequirePot( wrapT ) || filterHasMipmap(minFilter) ){
-      if( !isPowerOf2(texImageSource.width) || !isPowerOf2(texImageSource.height) )
-        texImageSource = await this.resizeToPOT( texImageSource, gl );
-    }
-
-
     this.glTexture = new Texture2D( gl, glFormat, gl.UNSIGNED_BYTE );
-    this.glTexture.fromImage( texImageSource );
 
-    
-    if( filterHasMipmap(minFilter) ){
-      gl.generateMipmap( gl.TEXTURE_2D );
-    }
+    await this.source.setupTexture(this.glTexture, wrapS, wrapT, minFilter, magFilter);
+
+    this.glTexture.bind();
 
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, magFilter);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, minFilter);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrapS);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrapT);
+    gl.bindTexture(gl.TEXTURE_2D, null);
 
     this._glTextureDeferred.resolve( this.glTexture );
-
-  }
-
-  async resizeToPOT( source: TexImageSource, gl : GLContext ) : Promise<TexImageSource> {
-    // throw new Error( "Not implemented - Texture source need to be resized to power of 2" );
-    // return source;
-    const canvas = document.createElement('canvas');
-    const context = canvas.getContext('2d');
-    canvas.width  = nearestPowerOf2( source.width );
-    canvas.height = nearestPowerOf2( source.height );
-    
-    if( source instanceof ImageData ){
-      const imageBitmap = await  createImageBitmap( source, 0, 0, canvas.width, canvas.height );
-      context.drawImage(imageBitmap, 0, 0, canvas.width, canvas.height);
-    } else {
-      context.drawImage(source, 0, 0, canvas.width, canvas.height);
-    }
-
-    return canvas;
-    // return context.createImageData( canvas.width, canvas.height );
 
   }
   

--- a/src/extensions/MMP_compressed_texture/CompressedImage.ts
+++ b/src/extensions/MMP_compressed_texture/CompressedImage.ts
@@ -1,0 +1,51 @@
+import Image from "../../elements/Image";
+import GltfLoader from "../../io/GltfLoader";
+import Gltf2 from "../../types/Gltf2";
+import TextureLoader from "./TextureLoader";
+import TextureDefinition from "./KTXParser";
+import Texture2D from "nanogl/texture-2d";
+
+export default class CompressedImage extends Image {
+
+  texDataSource: TextureDefinition;
+
+  async parseCompressed(gltfLoader: GltfLoader, data: Gltf2.IImage, texLoader: TextureLoader): Promise<any> {
+
+    const codec = texLoader.getCodec();
+    if (data.uri) {
+      this.uri = data.uri;
+      this.resolvedUri = gltfLoader.resolveUri(this.uri);
+      this.resolvedUri = codec.transformPath(this.resolvedUri);
+    }
+
+    let rawData = await gltfLoader.gltfIO.loadBinaryResource(this.resolvedUri, gltfLoader.abortSignal);
+    this.texDataSource = codec.parser.parse(rawData);
+
+  }
+
+  public async setupTexture(texture: Texture2D, wrapS: GLenum, wrapT: GLenum, minFilter: GLenum, magFilter: GLenum) {
+
+    const gl = texture.gl;
+
+    texture.bind();
+
+    var mips = this.texDataSource.surfaces[0];
+    var fmt = this.texDataSource.format;
+    var w = this.texDataSource.width;
+    var h = this.texDataSource.height;
+
+    for (var i = 0; i < mips.length; i++) {
+      var m = mips[i]
+      gl.compressedTexImage2D(gl.TEXTURE_2D, i, fmt, w, h, 0, m);
+      w = w >> 1;
+      h = h >> 1;
+    };
+
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, magFilter);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, minFilter);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrapS);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrapT);
+
+  }
+
+}

--- a/src/extensions/MMP_compressed_texture/KTXParser.ts
+++ b/src/extensions/MMP_compressed_texture/KTXParser.ts
@@ -1,0 +1,112 @@
+
+const MAGIC = new Uint8Array([0xAB, 0x4B, 0x54, 0x58, 0x20, 0x31, 0x31, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A]);
+
+
+function CheckMagic(f) {
+  for (var i = 0; i < 12; i++) {
+    if (f[i] !== MAGIC[i]) return false;
+  }
+  return true;
+}
+
+export default interface TextureDefinition{
+
+  width: number,
+  height: number,
+  surfaces: Array<Array<ArrayBufferView>>,
+  format: GLenum,
+  cubemap: boolean
+  
+}
+
+
+export default class Parser {
+
+
+  parse = (source: ArrayBuffer) => {
+
+    const magic = new Uint8Array(source, 0, 12);
+    if (!CheckMagic(magic)) {
+      throw new Error("[KTXParser] Bad Magic");
+    }
+
+    const headerLength = 64; // bytes
+    const buffer = new DataView(source);
+
+    const lendian = (buffer.getUint32(12, true) === 0x04030201);
+
+    let ptr = 16;
+
+    const glType                = buffer.getUint32(ptr, lendian); ptr += 4;
+    const glTypeSize            = buffer.getUint32(ptr, lendian); ptr += 4;
+    const glFormat              = buffer.getUint32(ptr, lendian); ptr += 4;
+    const glInternalFormat      = buffer.getUint32(ptr, lendian); ptr += 4;
+    const glBaseInternalFormat  = buffer.getUint32(ptr, lendian); ptr += 4;
+    const pixelWidth            = buffer.getUint32(ptr, lendian); ptr += 4;
+    const pixelHeight           = buffer.getUint32(ptr, lendian); ptr += 4;
+    const pixelDepth            = buffer.getUint32(ptr, lendian); ptr += 4;
+    const numberOfArrayElements = buffer.getUint32(ptr, lendian); ptr += 4;
+    const numberOfFaces         = buffer.getUint32(ptr, lendian); ptr += 4;
+    const numberOfMipmapLevels  = buffer.getUint32(ptr, lendian); ptr += 4;
+    const bytesOfKeyValueData   = buffer.getUint32(ptr, lendian); ptr += 4;
+
+    // skip KeyValueData
+    ptr += bytesOfKeyValueData;
+
+    const numMips = (numberOfMipmapLevels > 0) ? numberOfMipmapLevels : 1;
+    const numSurfs = (numberOfArrayElements > 0) ? numberOfArrayElements : 1;
+    const numFaces = (numberOfFaces > 0) ? numberOfFaces : 1;
+    const pixDepth = (pixelDepth > 0) ? pixelDepth : 1;
+
+
+
+    const surfaces : Array<Array<ArrayBufferView>> = [];
+
+    for (var faceIndex = 0; faceIndex < numFaces; faceIndex++) {
+      surfaces.push([]);
+    }
+
+    for (var i = 0; i < numMips; i++) {
+      const imageSize = buffer.getUint32(ptr, lendian); ptr += 4;
+
+      const imageSizeRounded = imageSize & ~3;
+
+      for (var surfIndex = 0; surfIndex < numSurfs; surfIndex++) {
+
+        for (var faceIndex = 0; faceIndex < numFaces; faceIndex++) {
+
+          let byteArray = new Uint8Array(buffer.buffer, ptr, imageSizeRounded);
+          ptr += imageSizeRounded;
+          surfaces[faceIndex].push(byteArray);
+
+        }
+
+      }
+
+      // mip padding
+    }
+
+    // console.log( 'glType                : '+glType                );
+    // console.log( 'glTypeSize            : '+glTypeSize            );
+    // console.log( 'glFormat              : '+glFormat              );
+    // console.log( 'glInternalFormat      : '+glInternalFormat      );
+    // console.log( 'glBaseInternalFormat  : '+glBaseInternalFormat  );
+    // console.log( 'pixelWidth            : '+pixelWidth            );
+    // console.log( 'pixelHeight           : '+pixelHeight           );
+    // console.log( 'pixelDepth            : '+pixelDepth            );
+    // console.log( 'numberOfArrayElements : '+numberOfArrayElements );
+    // console.log( 'numberOfFaces         : '+numberOfFaces         );
+    // console.log( 'numberOfMipmapLevels  : '+numberOfMipmapLevels  );
+    // console.log( 'bytesOfKeyValueData   : '+bytesOfKeyValueData   );
+
+    return {
+      width: pixelWidth,
+      height: pixelHeight,
+      surfaces: surfaces,
+      format: glInternalFormat,
+      cubemap: false
+    } as TextureDefinition;
+
+  }
+
+}

--- a/src/extensions/MMP_compressed_texture/TextureLoader.ts
+++ b/src/extensions/MMP_compressed_texture/TextureLoader.ts
@@ -1,0 +1,127 @@
+import { GLContext } from 'nanogl/types';
+import KTXParser from "./KTXParser";
+
+const DXT_EXTS = [
+  'WEBGL_compressed_texture_s3tc',
+  'MOZ_WEBGL_compressed_texture_s3tc',
+  'WEBKIT_WEBGL_compressed_texture_s3tc',
+]
+
+const PVR_EXTS = [
+  'WEBGL_compressed_texture_pvrtc',
+  'WEBKIT_WEBGL_compressed_texture_pvrtc',
+]
+
+const ETC_EXTS = [
+  'WEBGL_compressed_texture_etc1',
+  'WEBKIT_WEBGL_compressed_texture_etc1',
+]
+
+// TODO
+// const ASTC_EXTS = [
+//   'WEBGL_compressed_texture_astc'
+// ]
+
+function pickExtension(gl, array) {
+  var ext = null;
+  for (const extStr of array) {
+    ext = gl.getExtension(extStr);
+    if (ext) break;
+  }
+  return ext;
+}
+
+
+export class TextureCodec {
+
+  parser: KTXParser;
+  suffix: string;
+  compressed: boolean;
+  ext: GLenum;
+
+  constructor(parser, compressed, suffix, extension) {
+
+    this.parser = parser;
+    this.suffix = suffix;
+    this.compressed = compressed;
+
+    this.ext = extension;
+
+  }
+
+
+  transformPath = (basePath) => {
+    return basePath + this.suffix;
+  }
+
+
+  isSupported() {
+    return !!this.ext || (!this.compressed);
+  }
+
+}
+
+
+export default class TextureLoader {
+
+
+  DXTCodec: TextureCodec
+  PVRCodec: TextureCodec
+  ETCCodec: TextureCodec
+  // TODO
+  // ASTCCodec: TextureCodec
+
+  constructor() {
+
+    let cvs = document.createElement("canvas");
+    let gl = <GLContext>(
+      cvs.getContext('webgl2', {}) ||
+      cvs.getContext('webgl', {}) ||
+      cvs.getContext('experimental-webgl', {}) ||
+      cvs.getContext('webgl'));
+
+    this.DXTCodec = new TextureCodec(new KTXParser(), true, '.dxt.ktx', pickExtension(gl, DXT_EXTS));
+    this.PVRCodec = new TextureCodec(new KTXParser(), true, '.pvr.ktx', pickExtension(gl, PVR_EXTS));
+    this.ETCCodec = new TextureCodec(new KTXParser(), true, '.etc.ktx', pickExtension(gl, ETC_EXTS));
+
+    // TODO
+    // this.ASTCCodec = new TextureCodec(new KTXParser(), true, '.astc.ktx', pickExtension(gl, ASTC_EXTS));
+
+    let loseExt = gl.getExtension('WEBGL_lose_context');
+    if (loseExt) {
+      loseExt.loseContext();
+    }
+    cvs = null;
+    gl = null;
+
+  }
+
+  hasCodec() {
+
+    return this.DXTCodec.isSupported() ||
+      this.DXTCodec.isSupported() ||
+      this.ETCCodec.isSupported()
+
+  }
+
+  getCodec() {
+
+    // TODO
+    // if (this.ASTCCodec.isSupported()) {
+    //   return this.ASTCCodec
+    // }
+
+    if (this.DXTCodec.isSupported()) {
+      return this.DXTCodec
+    }
+    else if (this.PVRCodec.isSupported()) {
+      return this.PVRCodec
+    }
+    else if (this.ETCCodec.isSupported()) {
+      return this.ETCCodec
+    }
+
+  }
+
+
+}

--- a/src/extensions/MMP_compressed_texture/index.ts
+++ b/src/extensions/MMP_compressed_texture/index.ts
@@ -1,0 +1,61 @@
+import { IExtensionInstance, IExtensionFactory } from "../IExtension";
+import Gltf2 from "../../types/Gltf2";
+import { ElementOfType, PropertyType, AnyElement } from "../../types/Elements";
+import GltfLoader from "../../io/GltfLoader";
+import GltfTypes from "../../types/GltfTypes";
+import Image from "../../elements/Image";
+import CompressedImage from "./CompressedImage";
+import TextureLoader from "./TextureLoader";
+
+/**
+ * Load ktx textures into image
+ * Resolve the compressed supported type
+ */
+
+const EXT_ID: string = 'MMP_compressed_texture';
+
+class Instance implements IExtensionInstance {
+
+  readonly name: string = EXT_ID;
+  readonly priority: number = 1;
+
+  loader: GltfLoader;
+  textureLoader: TextureLoader;
+
+  constructor(gltfLoader: GltfLoader) {
+    this.loader = gltfLoader;
+    this.textureLoader = new TextureLoader();
+  }
+
+  acceptElement<P extends Gltf2.Property>(data: P, element: ElementOfType<PropertyType<P>>): null | Promise<ElementOfType<PropertyType<P>>>;
+
+  async acceptElement(data: Gltf2.Property, element: Image): null | Promise<Image> {
+
+    return element;
+
+  }
+
+  loadElement<P extends Gltf2.Property>(data: P): Promise<ElementOfType<PropertyType<P>>>;
+  loadElement(data: Gltf2.Property): Promise<AnyElement> {
+
+    // TODO :
+    // Move to extenstion not extras
+    let hasCompressed = data.gltftype === GltfTypes.IMAGE && data.extras && data.extras.MMP_compressed_texture;
+    hasCompressed = hasCompressed && this.textureLoader.hasCodec();
+    if (!hasCompressed)
+      return null;
+
+    const comp = new CompressedImage();
+    return comp.parseCompressed(this.loader, data as Gltf2.IImage, this.textureLoader).then(() => comp);
+
+  }
+
+}
+
+
+export default class MMP_compressed_texture implements IExtensionFactory {
+  readonly name: string = EXT_ID;
+  createInstance(gltfLoader: GltfLoader): IExtensionInstance {
+    return new Instance(gltfLoader);
+  }
+}


### PR DESCRIPTION
Implement MMP_compressed_texture has extra on images :

```
"images": [
    {
        "uri": "Assets/Models/Apple/Red_Apple_Albedo.png",
        "name": "Red_Apple_Albedo",
        "extras": {
        "MMP_compressed_texture": true
        }
    }
],
```

If true, loader will try to find compatible texture codec between dxt1, etc1, pvr4bpp. If none available fallback to jpg / png.

Loader will try to load ` { texture_path }/{ texture_name_with_extension }.{ dxt || etc || pvr }.ktx` file.

Ex files structure :
``` 
Assets/Models/Apple/Red_Apple_Albedo.png
Assets/Models/Apple/Red_Apple_Albedo.png.etc.ktx
Assets/Models/Apple/Red_Apple_Albedo.png.dxt.ktx
Assets/Models/Apple/Red_Apple_Albedo.png.pvr.ktx
```

Note :
Mip map generation for texture has moved into image, as it is the ktx file who knows if the texture contains mip map or not.
