### PR TITLE
[Fix] Animation duration use maxTime samplers duration

### DIFF
--- a/src/elements/Animation.ts
+++ b/src/elements/Animation.ts
@@ -48,7 +48,7 @@ export default class Animation implements IElement {
     this.samplers = await Promise.all( samplerPromises );
 
     for (const sampler of this.samplers) {
-      this.duration = Math.max( sampler.maxTime );
+      this.duration = Math.max( sampler.maxTime, this.duration );
     }
 
     const channelPromises = data.channels.map( (data)=>gltfLoader._loadElement(data) );


### PR DESCRIPTION
This may be a non intended behavior :
If multiple samplers with different duration are present in an Animation element, the duration property will only take into account the last sampler, leading to wrong duration if previous ones are longer.

The fix is to ensure the duration property is always the longer possible.